### PR TITLE
add build stage to docker, add ca-certificates to application image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
+# Build
+FROM golang:1 as build
+
+WORKDIR /go/src/github.com/gmauleon/alertmanager-zabbix-provisioner
+ADD . .
+
+RUN go get -d -v ./...
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o alertmanager-zabbix-provisioner .
+
+# Run
 FROM alpine:latest
+
+# add actual CA certificates
+RUN apk add --update ca-certificates && update-ca-certificates
 
 RUN adduser provisioner -s /bin/false -D provisioner
 
 RUN mkdir -p /etc/provisioner
 COPY config.yaml /etc/provisioner
 
-COPY alertmanager-zabbix-provisioner /usr/bin
-RUN chmod +x /usr/bin/alertmanager-zabbix-provisioner
+COPY --from=build /go/src/github.com/gmauleon/alertmanager-zabbix-provisioner/alertmanager-zabbix-provisioner /usr/bin
 
 USER provisioner
 


### PR DESCRIPTION
Build stage make user be able to rebuild the image without having go installed on his or her machine.
ca-certificates allow not to include certificate if your Zabbix server HTTPS certificate is signed by trusted authority.